### PR TITLE
Small Fixes to Tutorial and Code Generation

### DIFF
--- a/public/assets/js/script.js
+++ b/public/assets/js/script.js
@@ -986,11 +986,19 @@ function displayCyData() {
       var secondHost = edge["target"].split('-')[0];
       var portNameFirstHost = edge["source"]+"-"+edge["target"];
       var portNameSecondHost = edge["target"]+"-"+edge["source"];
+
+      var parentFirstHost = cy.$( `node[name="${edge.parentSource}"]`);
+      var parentSecondHost = cy.$( `node[name="${edge.parentTarget}"]`);
       
-      startContainers = startContainers + "docker exec "+firstHost+" ip link set " + portNameFirstHost +" promisc on \n"
-      startContainers = startContainers + "docker exec "+secondHost+" ip link set " + portNameSecondHost +" promisc on \n"
-      startContainers = startContainers + "docker exec "+ firstHost +" ethtool -K "+ portNameFirstHost + "tx off tx off \n";
-      startContainers = startContainers + "docker exec "+ secondHost +" ethtool -K "+ portNameSecondHost + "tx off tx off \n";
+      if(parentFirstHost[0]["_private"]["data"]["type"] == "Host"){
+	startContainers = startContainers + "docker exec "+firstHost+" ip link set " + portNameFirstHost +" promisc on \n"
+	startContainers = startContainers + "docker exec "+ firstHost +" ethtool -K "+ portNameFirstHost + " tx off tx off \n";
+      }
+
+      if(parentSecondHost[0]["_private"]["data"]["type"] == "Host"){
+	startContainers = startContainers + "docker exec "+secondHost+" ip link set " + portNameSecondHost +" promisc on \n"
+	startContainers = startContainers + "docker exec "+ secondHost +" ethtool -K "+ portNameSecondHost + " tx off tx off \n";
+      }
       
     });
     // Configura caso haja TCP Offloading ativo

--- a/tutorials/Tutorial1/tutorialConfig.sh
+++ b/tutorials/Tutorial1/tutorialConfig.sh
@@ -31,34 +31,34 @@ PIDsw1=$(docker inspect -f '{{.State.Pid}}' sw1)
 
  
  echo "Creating VETH Peers"
- sudo ip link add host1-p1-sw1-p1 type veth peer name sw1-p1-host1-p1 
-sudo ip link add host2-p1-host1-p1 type veth peer name host1-p1-host2-p1 
+ sudo ip link add sw1-p2-host2-p1 type veth peer name host2-p1-sw1-p2 
+sudo ip link add host1-p1-sw1-p1 type veth peer name sw1-p1-host1-p1 
 
  
  echo "Set Namespaces" 
- sudo ip link set host1-p1-sw1-p1 netns $PIDhost1 
+ sudo ip link set sw1-p2-host2-p1 netns $PIDsw1 
+sudo ip link set host2-p1-sw1-p2 netns $PIDhost2 
+sudo ip link set host1-p1-sw1-p1 netns $PIDhost1 
 sudo ip link set sw1-p1-host1-p1 netns $PIDsw1 
-sudo ip link set host2-p1-host1-p1 netns $PIDhost2 
-sudo ip link set host1-p1-host2-p1 netns $PIDhost1 
 
  
  echo "Set network interfaces" 
- sudo nsenter -t $PIDhost1 -n ip addr add 10.0.1.2/24 dev host1-p1-sw1-p1 
+ sudo nsenter -t $PIDsw1 -n ip addr add 10.0.2.1/24 dev sw1-p2-host2-p1 
+sudo nsenter -t $PIDsw1 -n ip link set dev sw1-p2-host2-p1 address 00:00:00:00:02:01 
+sudo nsenter -t $PIDsw1 -n ip link set sw1-p2-host2-p1 up 
+sudo nsenter -t $PIDhost2 -n ip addr add 10.0.2.2/24 dev host2-p1-sw1-p2 
+sudo nsenter -t $PIDhost2 -n ip link set dev host2-p1-sw1-p2 address 00:00:00:00:02:02 
+sudo nsenter -t $PIDhost2 -n ip link set host2-p1-sw1-p2 up 
+sudo nsenter -t $PIDhost1 -n ip addr add 10.0.1.2/24 dev host1-p1-sw1-p1 
 sudo nsenter -t $PIDhost1 -n ip link set dev host1-p1-sw1-p1 address 00:00:00:00:01:02 
 sudo nsenter -t $PIDhost1 -n ip link set host1-p1-sw1-p1 up 
-sudo nsenter -t $PIDsw1 -n ip addr add 10.0.1.2/24 dev sw1-p1-host1-p1 
-sudo nsenter -t $PIDsw1 -n ip link set dev sw1-p1-host1-p1 address 00:00:00:00:01:02 
+sudo nsenter -t $PIDsw1 -n ip addr add 10.0.1.1/24 dev sw1-p1-host1-p1 
+sudo nsenter -t $PIDsw1 -n ip link set dev sw1-p1-host1-p1 address 00:00:00:00:01:01 
 sudo nsenter -t $PIDsw1 -n ip link set sw1-p1-host1-p1 up 
-sudo nsenter -t $PIDhost2 -n ip addr add 10.0.2.2/24 dev host2-p1-host1-p1 
-sudo nsenter -t $PIDhost2 -n ip link set dev host2-p1-host1-p1 address 00:00:00:00:02:02 
-sudo nsenter -t $PIDhost2 -n ip link set host2-p1-host1-p1 up 
-sudo nsenter -t $PIDhost1 -n ip addr add 10.0.2.2/24 dev host1-p1-host2-p1 
-sudo nsenter -t $PIDhost1 -n ip link set dev host1-p1-host2-p1 address 00:00:00:00:02:02 
-sudo nsenter -t $PIDhost1 -n ip link set host1-p1-host2-p1 up 
+docker exec host2 ip link set host2-p1-sw1-p2 promisc on 
+docker exec host2 ethtool -K host2-p1-sw1-p2 tx off tx off 
 docker exec host1 ip link set host1-p1-sw1-p1 promisc on 
-docker exec sw1 ip link set sw1-p1-host1-p1 promisc on 
-docker exec host2 ip link set host2-p1-host1-p1 promisc on 
-docker exec host1 ip link set host1-p1-host2-p1 promisc on 
+docker exec host1 ethtool -K host1-p1-sw1-p1 tx off tx off 
 
  
  echo "Setting default route for hosts (Check the code for custom routes) " 
@@ -67,9 +67,10 @@ docker exec host1 ip link set host1-p1-host2-p1 promisc on
  echo "By default, this script will set the host default gateway to the switch interface connected to the host" 
  #By default, this script will set the host default gateway to the switch interface connected to the host 
 #Change this lines to set custon routes 
-docker exec host1 route add default gw 10.0.1.2
- 
+docker exec host2 route add default gw 10.0.2.1
+ docker exec host1 route add default gw 10.0.1.1
  docker exec sw1 sh -c 'echo 0 >> /proc/sys/net/ipv4/ip_forward' 
-docker exec sw1 sh -c 'nohup simple_switch  --thrift-port 50001  -i 1@sw1-p1-host1-p1 code.json --log-console >> /tmp/switch.log &' 
-docker exec sw1 sh -c 'echo "table_add MyIngress.ipv4_lpm ipv4_forward 10.0.1.2  => 00:00:00:00:01:02 1" | simple_switch_CLI --thrift-port 50001'  
-docker exec sw1 sh -c 'echo "table_add MyIngress.ipv4_lpm ipv4_forward 10.0.2.2 =>  00:00:00:00:02:02 2" | simple_switch_CLI --thrift-port 50001'  
+docker exec sw1 sh -c 'nohup simple_switch  --thrift-port 50001  -i 1@sw1-p1-host1-p1 -i 2@sw1-p2-host2-p1 code.json --log-console >> /tmp/switch.log &' 
+docker exec sw1 sh -c 'echo "table_add MyIngress.ipv4_lpm ipv4_forward 10.0.1.2/32  => 00:00:00:00:01:02 1" | simple_switch_CLI --thrift-port 50001'  
+docker exec sw1 sh -c 'echo "table_add MyIngress.ipv4_lpm ipv4_forward 10.0.2.2/32 =>  00:00:00:00:02:02 2" | simple_switch_CLI --thrift-port 50001'  
+

--- a/tutorials/Tutorial1/tutorialTopology.json
+++ b/tutorials/Tutorial1/tutorialTopology.json
@@ -27,8 +27,8 @@
           "id": "host1-p1",
           "name": "host1-p1",
           "parent": "host1",
-          "ip": "10.0.2.2/24",
-          "mac": "00:00:00:00:02:02",
+          "ip": "10.0.1.2/24",
+          "mac": "00:00:00:00:01:02",
           "type": "Port"
         },
         "position": {
@@ -96,15 +96,15 @@
           "label": "sw1: code.json",
           "apiPorts": "50001",
           "p4code": "code.json",
-          "entries": "table_add MyIngress.ipv4_lpm ipv4_forward 10.0.1.2  => 00:00:00:00:01:02 1;table_add MyIngress.ipv4_lpm ipv4_forward 10.0.2.2 =>  00:00:00:00:02:02 2\n"
+          "entries": "table_add MyIngress.ipv4_lpm ipv4_forward 10.0.1.2/32  => 00:00:00:00:01:02 1;table_add MyIngress.ipv4_lpm ipv4_forward 10.0.2.2/32 =>  00:00:00:00:02:02 2"
         },
         "position": {
-          "x": 53.65384615384616,
-          "y": -43.84615384615385
+          "x": 47.5,
+          "y": -110.76923076923075
         },
         "group": "nodes",
         "removed": false,
-        "selected": false,
+        "selected": true,
         "selectable": true,
         "locked": false,
         "grabbable": true,
@@ -116,13 +116,13 @@
           "id": "sw1-p1",
           "name": "sw1-p1",
           "parent": "sw1",
-          "ip": "10.0.1.2/24",
-          "mac": "00:00:00:00:01:02",
+          "ip": "10.0.1.1/24",
+          "mac": "00:00:00:00:01:01",
           "type": "Port"
         },
         "position": {
-          "x": 36.15384615384617,
-          "y": -43.84615384615385
+          "x": 30.000000000000007,
+          "y": -110.76923076923075
         },
         "group": "nodes",
         "removed": false,
@@ -138,13 +138,13 @@
           "id": "sw1-p2",
           "name": "sw1-p2",
           "parent": "sw1",
-          "ip": "",
-          "mac": "",
+          "ip": "10.0.2.1/24",
+          "mac": "00:00:00:00:02:01",
           "type": "Port"
         },
         "position": {
-          "x": 71.15384615384616,
-          "y": -43.84615384615385
+          "x": 64.99999999999999,
+          "y": -110.76923076923075
         },
         "group": "nodes",
         "removed": false,
@@ -159,19 +159,19 @@
     "edges": [
       {
         "data": {
-          "source": "host1-p1",
-          "target": "sw1-p1",
-          "interface": "host1-p1-sw1-p1",
+          "source": "sw1-p2",
+          "target": "host2-p1",
+          "interface": "sw1-p2-host2-p1",
           "customEdge": false,
           "delay": "",
           "bandwidth": "",
-          "parentSource": "host1",
-          "parentTarget": "sw1",
-          "sourceIp": "10.0.1.2/24",
-          "targetIp": "10.0.1.2/24",
-          "sourceMac": "00:00:00:00:01:02",
-          "targetMac": "00:00:00:00:01:02",
-          "id": "615769d4-cc13-44ee-ad3a-6887ae613321"
+          "parentSource": "sw1",
+          "parentTarget": "host2",
+          "sourceIp": "10.0.2.1/24",
+          "targetIp": "10.0.2.2/24",
+          "sourceMac": "00:00:00:00:02:01",
+          "targetMac": "00:00:00:00:02:02",
+          "id": "f548c36d-67ad-435f-b721-fa2086e9440f"
         },
         "position": {
           "x": 0,
@@ -188,19 +188,19 @@
       },
       {
         "data": {
-          "source": "host2-p1",
-          "target": "host1-p1",
-          "interface": "host2-p1-host1-p1",
+          "source": "host1-p1",
+          "target": "sw1-p1",
+          "interface": "host1-p1-sw1-p1",
           "customEdge": false,
           "delay": "",
           "bandwidth": "",
-          "parentSource": "host2",
-          "parentTarget": "host1",
-          "sourceIp": "10.0.2.2/24",
-          "targetIp": "10.0.2.2/24",
-          "sourceMac": "00:00:00:00:02:02",
-          "targetMac": "00:00:00:00:02:02",
-          "id": "72adb945-1b40-4909-b2a4-c7d40c8ce6e5"
+          "parentSource": "host1",
+          "parentTarget": "sw1",
+          "sourceIp": "10.0.1.2/24",
+          "targetIp": "10.0.1.1/24",
+          "sourceMac": "00:00:00:00:01:02",
+          "targetMac": "00:00:00:00:01:01",
+          "id": "a8b0b57d-b2ec-4d38-bdfc-a85ddd2588b4"
         },
         "position": {
           "x": 0,
@@ -331,8 +331,8 @@
   "panningEnabled": true,
   "userPanningEnabled": true,
   "pan": {
-    "x": 347.49999999999994,
-    "y": 185.00759054337496
+    "x": 218.5,
+    "y": 306.15
   },
   "boxSelectionEnabled": true,
   "renderer": {


### PR DESCRIPTION
In the original tutorial topology, the first host has an edge directly to the second host:
<img width="908" alt="image" src="https://github.com/user-attachments/assets/5de7e018-fc33-4073-9a7e-b395da468db8">
The fixed version connects the first host port to the corresponding switch port:
<img width="908" alt="image" src="https://github.com/user-attachments/assets/db2a7d07-5316-45bf-be68-279277a70852">




The other fix corresponds to adding an space to ethtool comands and making sure they are not being generated to run on the switches, avoiding a run error. 
<img width="776" alt="image" src="https://github.com/user-attachments/assets/92a576af-947b-4635-88ea-bed49e2fc41f">
<img width="776" alt="image" src="https://github.com/user-attachments/assets/e9359d3d-b0a9-4b00-a5e3-99f2c66e0421">

